### PR TITLE
[PR #49 follow-up] Restore TypingEngine.backspace status object contract

### DIFF
--- a/src/features/typing-game/logic/typingEngine.ts
+++ b/src/features/typing-game/logic/typingEngine.ts
@@ -112,10 +112,10 @@ export class TypingEngine {
   /**
    * バックスペース（戻る）処理の総合窓口
    */
-  backspace(): BackspaceStatus {
+  backspace(): { status: BackspaceStatus } {
     if (this.cannotGoBack()) {
       this.segIndex = 0;
-      return "EMPTY";
+      return { status: "EMPTY" };
     }
 
     this.keepIndexAtLast();
@@ -123,8 +123,8 @@ export class TypingEngine {
     const segment = this.segments[this.segIndex];
 
     // 通常のバックスペース処理
-    segment.backspace();
-    return "BACK";
+    const result = segment.backspace();
+    return { status: result };
   }
 
   // 戻れるかの判定

--- a/src/hooks/tests/TypingEngine.test.ts
+++ b/src/hooks/tests/TypingEngine.test.ts
@@ -31,7 +31,7 @@ describe("TypingEngine ロジックテスト", () => {
 
     // 3. BSで戻る -> 救済なので一気に消える ("")
     const bsResult = engine.backspace();
-    expect(bsResult);
+    expect(bsResult.status).toBe("BACK_EXPANDED");
     expect(engine.segments[1].inputBuffer).toBe("");
   });
 
@@ -101,7 +101,7 @@ describe("TypingEngine ロジックテスト", () => {
     const thirdResult = engine.backspace();
 
     // 1. ステータスは常にペナルティ
-    expect(thirdResult);
+    expect(thirdResult.status).toBe("EMPTY");
     // 2. インデックスがマイナス（-1など）に突き抜けていないか
     expect(engine.segIndex).toBe(0);
     // 3. 最初のセグメントが消滅していないか
@@ -113,7 +113,7 @@ describe("TypingEngine ロジックテスト", () => {
     const engine = new TypingEngine("");
 
     expect(engine.segments.length).toBe(0);
-    expect(engine.backspace());
+    expect(engine.backspace().status).toBe("EMPTY");
     expect(engine.segIndex).toBe(0);
   });
 });


### PR DESCRIPTION
### Motivation
- Fix a breaking API regression where `TypingEngine.backspace` began returning bare strings while existing callers and tests expect an object with a `.status` field, causing runtime failures after the refactor.

### Description
- Restore `backspace()` to return `{ status: BackspaceStatus }` and forward the underlying `Segment.backspace()` result as the `status` payload, and update `src/hooks/tests/TypingEngine.test.ts` to assert explicit `.status` values.

### Testing
- Ran `npx vitest run src/hooks/tests/TypingEngine.test.ts` and the test file passed (7 tests, all green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef646fe5208320afc0eb29e63b6750)